### PR TITLE
Board Manager Package Additions

### DIFF
--- a/hardware/adafruit/avr/boards.txt
+++ b/hardware/adafruit/avr/boards.txt
@@ -41,13 +41,13 @@ gemma.name=Adafruit Gemma 8MHz
 gemma.bootloader.low_fuses=0xF1
 gemma.bootloader.high_fuses=0xD5
 gemma.bootloader.extended_fuses=0xFE
-gemma.bootloader.tool=avrdude
+gemma.bootloader.tool=arduino:avrdude
 gemma.build.mcu=attiny85
 gemma.build.f_cpu=8000000L
 gemma.build.core=arduino:arduino
 gemma.build.variant=tiny8
 gemma.build.board=AVR_GEMMA
-gemma.upload.tool=avrdude
+gemma.upload.tool=arduino:avrdude
 gemma.upload.maximum_size=5310
 
 ##############################################################
@@ -56,13 +56,13 @@ trinket3.name=Adafruit Trinket 8MHz
 trinket3.bootloader.low_fuses=0xF1
 trinket3.bootloader.high_fuses=0xD5
 trinket3.bootloader.extended_fuses=0xFE
-trinket3.bootloader.tool=avrdude
+trinket3.bootloader.tool=arduino:avrdude
 trinket3.build.mcu=attiny85
 trinket3.build.f_cpu=8000000L
 trinket3.build.core=arduino:arduino
 trinket3.build.variant=tiny8
 trinket3.build.board=AVR_TRINKET3
-trinket3.upload.tool=avrdude
+trinket3.upload.tool=arduino:avrdude
 trinket3.upload.maximum_size=5310
 
 ##############################################################
@@ -71,19 +71,39 @@ trinket5.name=Adafruit Trinket 16MHz
 trinket5.bootloader.low_fuses=0xF1
 trinket5.bootloader.high_fuses=0xD5
 trinket5.bootloader.extended_fuses=0xFE
-trinket5.bootloader.tool=avrdude
+trinket5.bootloader.tool=arduino:avrdude
 trinket5.build.mcu=attiny85
 trinket5.build.f_cpu=16000000L
 trinket5.build.core=arduino:arduino
 trinket5.build.variant=tiny8
 trinket5.build.board=AVR_TRINKET5
-trinket5.upload.tool=avrdude
+trinket5.upload.tool=arduino:avrdude
 trinket5.upload.maximum_size=5310
+
+##############################################################
+metro.name=Adafruit Metro
+metro.upload.tool=arduino:avrdude
+metro.upload.protocol=arduino
+metro.upload.maximum_size=32256
+metro.upload.maximum_data_size=2048
+metro.upload.speed=115200
+metro.bootloader.tool=arduino:avrdude
+metro.bootloader.low_fuses=0xFF
+metro.bootloader.high_fuses=0xDE
+metro.bootloader.extended_fuses=0x05
+metro.bootloader.unlock_bits=0x3F
+metro.bootloader.lock_bits=0x0F
+metro.bootloader.file=arduino:optiboot/optiboot_atmega328.hex
+metro.build.mcu=atmega328p
+metro.build.f_cpu=16000000L
+metro.build.board=AVR_METRO
+metro.build.core=arduino:arduino
+metro.build.variant=arduino:standard
 
 ##############################################################
 # Pro-Trinket 5V USB Programming Configuration
 protrinket5.name=Pro Trinket 5V/16MHz (USB)
-protrinket5.bootloader.tool=avrdude
+protrinket5.bootloader.tool=arduino:avrdude
 protrinket5.build.mcu=atmega328p
 protrinket5.build.f_cpu=16000000L
 protrinket5.build.core=arduino:arduino
@@ -96,7 +116,7 @@ protrinket5.upload.speed=115200
 ##############################################################
 # Pro-Trinket 3.3V USB Programming Configuration
 protrinket3.name=Pro Trinket 3V/12MHz (USB)
-protrinket3.bootloader.tool=avrdude
+protrinket3.bootloader.tool=arduino:avrdude
 protrinket3.build.mcu=atmega328p
 protrinket3.build.f_cpu=12000000L
 protrinket3.build.core=arduino:arduino
@@ -115,7 +135,7 @@ protrinket5ftdi.bootloader.extended_fuses=0x05
 protrinket5ftdi.bootloader.file=arduino:optiboot/optiboot_atmega328.hex
 protrinket5ftdi.bootloader.unlock_bits=0x3F
 protrinket5ftdi.bootloader.lock_bits=0x0F
-protrinket5ftdi.bootloader.tool=avrdude
+protrinket5ftdi.bootloader.tool=arudino:avrdude
 protrinket5ftdi.build.mcu=atmega328p
 protrinket5ftdi.build.f_cpu=16000000L
 protrinket5ftdi.build.core=arduino:arduino
@@ -129,7 +149,7 @@ protrinket5ftdi.upload.speed=115200
 ##############################################################
 # Pro-Trinket 3.3V Serial/FTDI Programming Configuration
 protrinket3ftdi.name=Pro Trinket 3V/12MHz (FTDI)
-protrinket3ftdi.bootloader.tool=avrdude
+protrinket3ftdi.bootloader.tool=arduino:avrdude
 protrinket3ftdi.bootloader.low_fuses=0xff
 protrinket3ftdi.bootloader.high_fuses=0xde
 protrinket3ftdi.bootloader.extended_fuses=0x05
@@ -145,3 +165,4 @@ protrinket3ftdi.upload.tool=arduino:avrdude
 protrinket3ftdi.upload.protocol=arduino
 protrinket3ftdi.upload.maximum_size=28672
 protrinket3ftdi.upload.speed=115200
+

--- a/hardware/adafruit/avr/platform.txt
+++ b/hardware/adafruit/avr/platform.txt
@@ -5,4 +5,32 @@
 # - https://github.com/arduino/Arduino/wiki/Arduino-Hardware-Cores-migration-guide-from-1.0-to-1.6
 #
 name=Adafruit Boards
-version=1.0.0
+version=1.2.0
+
+# AVR Uploader/Programmers tools
+# ------------------------------
+tools.avrdude.path={runtime.tools.avrdude.path}
+tools.avrdude.cmd.path={path}/bin/avrdude
+tools.avrdude.config.path={runtime.platform.path}/avrdude.conf
+
+tools.avrdude.upload.params.verbose=-v
+tools.avrdude.upload.params.quiet=-q -q
+tools.avrdude.upload.pattern="{cmd.path}" "-C{config.path}" {upload.verbose} -p{build.mcu} -c{upload.protocol} -P{serial.port} -b{upload.speed} -D "-Uflash:w:{build.path}/{build.project_name}.hex:i"
+
+tools.avrdude.program.params.verbose=-v
+tools.avrdude.program.params.quiet=-q -q
+tools.avrdude.program.pattern="{cmd.path}" "-C{config.path}" {program.verbose} -p{build.mcu} -c{protocol} {program.extra_params} "-Uflash:w:{build.path}/{build.project_name}.hex:i"
+
+tools.avrdude.erase.params.verbose=-v
+tools.avrdude.erase.params.quiet=-q -q
+tools.avrdude.erase.pattern="{cmd.path}" "-C{config.path}" {erase.verbose} -p{build.mcu} -c{protocol} {program.extra_params} -e -Ulock:w:{bootloader.unlock_bits}:m -Uefuse:w:{bootloader.extended_fuses}:m -Uhfuse:w:{bootloader.high_fuses}:m -Ulfuse:w:{bootloader.low_fuses}:m
+
+tools.avrdude.bootloader.params.verbose=-v
+tools.avrdude.bootloader.params.quiet=-q -q
+tools.avrdude.bootloader.pattern="{cmd.path}" "-C{config.path}" {bootloader.verbose} -p{build.mcu} -c{protocol} {program.extra_params} "-Uflash:w:{runtime.platform.path}/bootloaders/{bootloader.file}:i" -Ulock:w:{bootloader.lock_bits}:m
+
+# USB Default Flags
+# Default blank usb manufacturer will be filled it at compile time
+# - from numeric vendor ID, set to Unknown otherwise
+build.usb_manufacturer="Unknown"
+build.usb_flags=-DUSB_VID={build.vid} -DUSB_PID={build.pid} '-DUSB_MANUFACTURER={build.usb_manufacturer}' '-DUSB_PRODUCT={build.usb_product}'

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# The MIT License (MIT)
+#
+# Author: Todd Treece <todd@uniontownlabs.org>
+# Copyright (c) 2015 Adafruit Industries
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# these should be changed before packaging
+GCC_VERSION="4.8.1-arduino5"
+AVRDUDE_VERSION="6.0.1-arduino5"
+PACKAGE_VERSION="1.2.0"
+BOARD_DOWNLOAD_URL="https:\/\/adafruit.github.io\/arduino-board-index\/boards"
+
+# get package script directory
+REPO_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+# clean build dir
+cd $REPO_DIR
+rm -r build
+mkdir build
+cp templates/package.json build/package.json
+
+function archive() {
+
+  # args: archive_name source_path sha_return size_return
+
+  local  __sha=$3
+  local  __size=$4
+
+  echo "building $1.tar.bz2..."
+  cd $REPO_DIR
+  cp -a $2 build/$1
+  cd build
+  tar -jcf $1.tar.bz2 $1
+  rm -r $1
+
+  local sha=$(openssl dgst -sha256 $1.tar.bz2 | awk '{print $2}')
+  local size=$(ls -l | grep $1 | awk '{print $5}')
+
+  eval $__sha="'$sha'"
+  eval $__size="'$size'"
+
+}
+
+cd $REPO_DIR
+
+#update platform version
+sed -i .bak -e "s/^version=.*/version=$PACKAGE_VERSION/" hardware/adafruit/avr/platform.txt
+rm hardware/adafruit/avr/platform.txt.bak
+
+# create archives and get sha & size
+archive "adafruit-$PACKAGE_VERSION" hardware/adafruit/avr PACKAGESHA PACKAGESIZE
+
+cd $REPO_DIR
+
+# fill in board json template
+sed -i .bak -e "s/PACKAGEVERSION/$PACKAGE_VERSION/" \
+            -e "s/AVRDUDEVERSION/$AVRDUDE_VERSION/" \
+            -e "s/GCCVERSION/$GCC_VERSION/" \
+            -e "s/DOWNLOADURL/$BOARD_DOWNLOAD_URL/" \
+            -e "s/PACKAGESHA/$PACKAGESHA/" \
+            -e "s/PACKAGESIZE/$PACKAGESIZE/" build/package.json
+
+rm build/package.json.bak

--- a/templates/package.json
+++ b/templates/package.json
@@ -1,0 +1,43 @@
+{
+   "name":"Adafruit AVR Boards",
+   "architecture":"avr",
+   "version":"PACKAGEVERSION",
+   "category":"Adafruit",
+   "url":"DOWNLOADURL/adafruit-PACKAGEVERSION.tar.bz2",
+   "archiveFileName":"adafruit-PACKAGEVERSION.tar.bz2",
+   "checksum":"SHA-256:PACKAGESHA",
+   "size":"PACKAGESIZE",
+   "help":{
+      "online":"https://forums.adafruit.com/"
+   },
+   "boards":[
+      {
+         "name":"Adafruit Flora"
+      },
+      {
+         "name":"Adafruit Gemma 8MHz"
+      },
+      {
+         "name":"Adafruit Metro"
+      },
+      {
+         "name":"Adafruit Pro Trinket 5V/16MHz (USB)"
+      },
+      {
+         "name":"Adafruit Pro Trinket 3V/12MHz (USB)"
+      },
+      {
+         "name":"Adafruit Pro Trinket 5V/16MHz (FTDI)"
+      },
+      {
+         "name":"Adafruit Pro Trinket 3V/12MHz (FTDI)"
+      },
+      {
+         "name":"Adafruit Trinket 8MHz"
+      },
+      {
+         "name":"Adafruit Trinket 16MHz"
+      }
+   ],
+   "toolsDependencies":[]
+}


### PR DESCRIPTION
Adds:
- `package.sh` build script helper (only tested on os x)
- package JSON template for generating the JSON needed to add to the package index
- adafruit metro board to boards.txt
