### PR TITLE
Add Board Manager Updates

### DIFF
--- a/build_package.sh
+++ b/build_package.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# The MIT License (MIT)
+#
+# Author: Todd Treece <todd@uniontownlabs.org>
+# Copyright (c) 2015 Adafruit Industries
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+PACKAGE_VERSION="1.3.0"
+read -p "VERSION [${PACKAGE_VERSION}]: " input
+PACKAGE_VERSION="$input"
+
+
+# boards are served via github pages
+BOARD_DOWNLOAD_URL="https:\/\/adafruit.github.io\/arduino-board-index\/boards"
+
+# get package script directory
+REPO_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+read -r -d '' JSON <<'EOF'
+{
+   "name":"Adafruit AVR Boards",
+   "architecture":"avr",
+   "version":"PACKAGEVERSION",
+   "category":"Adafruit",
+   "url":"DOWNLOADURL/adafruit-PACKAGEVERSION.tar.bz2",
+   "archiveFileName":"adafruit-PACKAGEVERSION.tar.bz2",
+   "checksum":"SHA-256:PACKAGESHA",
+   "size":"PACKAGESIZE",
+   "help":{
+      "online":"https://forums.adafruit.com"
+   },
+   "boards":[
+      {
+         "name":"Adafruit Flora"
+      },
+      {
+         "name":"Adafruit Gemma 8MHz"
+      },
+      {
+         "name":"Adafruit Bluefruit Micro"
+      },
+      {
+         "name":"Adafruit Metro"
+      },
+      {
+         "name":"Adafruit Pro Trinket 5V/16MHz (USB)"
+      },
+      {
+         "name":"Adafruit Pro Trinket 3V/12MHz (USB)"
+      },
+      {
+         "name":"Adafruit Pro Trinket 5V/16MHz (FTDI)"
+      },
+      {
+         "name":"Adafruit Pro Trinket 3V/12MHz (FTDI)"
+      },
+      {
+         "name":"Adafruit Trinket 8MHz"
+      },
+      {
+         "name":"Adafruit Trinket 16MHz"
+      }
+   ],
+   "toolsDependencies":[]
+}
+EOF
+
+# clean build dir
+cd $REPO_DIR
+rm -r build
+mkdir build
+
+function archive() {
+
+  # args: archive_name source_path sha_return size_return
+
+  local  __sha=$3
+  local  __size=$4
+
+  echo "building $1.tar.bz2..."
+  cd $REPO_DIR
+  cp -a $2 build/$1
+  cd build
+  tar -jcf $1.tar.bz2 $1
+  rm -r $1
+
+  local sha=$(openssl dgst -sha256 $1.tar.bz2 | awk '{print $2}')
+  local size=$(ls -l | grep $1 | awk '{print $5}')
+
+  eval $__sha="'$sha'"
+  eval $__size="'$size'"
+
+}
+
+cd $REPO_DIR
+
+#update platform version
+sed -i .bak -e "s/^version=.*/version=$PACKAGE_VERSION/" hardware/adafruit/avr/platform.txt
+
+# create archives and get sha & size
+archive "adafruit-$PACKAGE_VERSION" hardware/adafruit/avr PACKAGESHA PACKAGESIZE
+
+cd $REPO_DIR
+
+# fill in board json templatee
+echo $JSON | sed -e "s/PACKAGEVERSION/$PACKAGE_VERSION/" \
+                 -e "s/DOWNLOADURL/$BOARD_DOWNLOAD_URL/" \
+                 -e "s/PACKAGESHA/$PACKAGESHA/" \
+                 -e "s/PACKAGESIZE/$PACKAGESIZE/" > build/package.json

--- a/build_package.sh
+++ b/build_package.sh
@@ -25,7 +25,7 @@
 
 PACKAGE_VERSION="1.3.0"
 read -p "VERSION [${PACKAGE_VERSION}]: " input
-PACKAGE_VERSION="$input"
+PACKAGE_VERSION=$input
 
 
 # boards are served via github pages
@@ -121,7 +121,7 @@ archive "adafruit-$PACKAGE_VERSION" hardware/adafruit/avr PACKAGESHA PACKAGESIZE
 cd $REPO_DIR
 
 # fill in board json templatee
-echo $JSON | sed -e "s/PACKAGEVERSION/$PACKAGE_VERSION/" \
-                 -e "s/DOWNLOADURL/$BOARD_DOWNLOAD_URL/" \
-                 -e "s/PACKAGESHA/$PACKAGESHA/" \
-                 -e "s/PACKAGESIZE/$PACKAGESIZE/" > build/package.json
+echo $JSON | sed -e "s/PACKAGEVERSION/$PACKAGE_VERSION/g" \
+                 -e "s/DOWNLOADURL/$BOARD_DOWNLOAD_URL/g" \
+                 -e "s/PACKAGESHA/$PACKAGESHA/g" \
+                 -e "s/PACKAGESIZE/$PACKAGESIZE/g" > build/package.json

--- a/hardware/adafruit/avr/boards.txt
+++ b/hardware/adafruit/avr/boards.txt
@@ -35,19 +35,50 @@ flora8.upload.tool=arduino:avrdude
 flora8.vid.0=0x239A
 flora8.pid.0=0x8004
 
+
+##############################################################
+# Flora Configuration
+bluefruitmicro.name=Adafruit Bluefruit Micro
+bluefruitmicro.bootloader.low_fuses=0xff
+bluefruitmicro.bootloader.high_fuses=0xd8
+bluefruitmicro.bootloader.extended_fuses=0xcb
+bluefruitmicro.bootloader.file=arduino:caterina/Caterina-Bluefruitmicro.hex
+bluefruitmicro.bootloader.unlock_bits=0x3F
+bluefruitmicro.bootloader.lock_bits=0x2F
+bluefruitmicro.bootloader.tool=arduino:avrdude
+bluefruitmicro.build.mcu=atmega32u4
+bluefruitmicro.build.f_cpu=8000000L
+bluefruitmicro.build.vid=0x239A
+bluefruitmicro.build.pid=0x800A
+bluefruitmicro.build.core=arduino:arduino
+bluefruitmicro.build.variant=bluefruitmicro
+bluefruitmicro.build.board=AVR_BLUEFRUITMICRO
+bluefruitmicro.build.usb_product="Bluefruit Micro"
+bluefruitmicro.build.usb_manufacturer="Adafruit"
+bluefruitmicro.build.extra_flags={build.usb_flags}
+bluefruitmicro.upload.protocol=avr109
+bluefruitmicro.upload.maximum_size=28672
+bluefruitmicro.upload.speed=57600
+bluefruitmicro.upload.disable_flushing=true
+bluefruitmicro.upload.use_1200bps_touch=true
+bluefruitmicro.upload.wait_for_upload_port=true
+bluefruitmicro.upload.tool=arduino:avrdude
+bluefruitmicro.vid.0=0x239A
+bluefruitmicro.pid.0=0x800A
+
 ##############################################################
 # Gemma Configuration
 gemma.name=Adafruit Gemma 8MHz
 gemma.bootloader.low_fuses=0xF1
 gemma.bootloader.high_fuses=0xD5
 gemma.bootloader.extended_fuses=0xFE
-gemma.bootloader.tool=avrdude
+gemma.bootloader.tool=arduino:avrdude
 gemma.build.mcu=attiny85
 gemma.build.f_cpu=8000000L
 gemma.build.core=arduino:arduino
 gemma.build.variant=tiny8
 gemma.build.board=AVR_GEMMA
-gemma.upload.tool=avrdude
+gemma.upload.tool=arduino:avrdude
 gemma.upload.maximum_size=5310
 
 ##############################################################
@@ -56,13 +87,13 @@ trinket3.name=Adafruit Trinket 8MHz
 trinket3.bootloader.low_fuses=0xF1
 trinket3.bootloader.high_fuses=0xD5
 trinket3.bootloader.extended_fuses=0xFE
-trinket3.bootloader.tool=avrdude
+trinket3.bootloader.tool=arduino:avrdude
 trinket3.build.mcu=attiny85
 trinket3.build.f_cpu=8000000L
 trinket3.build.core=arduino:arduino
 trinket3.build.variant=tiny8
 trinket3.build.board=AVR_TRINKET3
-trinket3.upload.tool=avrdude
+trinket3.upload.tool=arduino:avrdude
 trinket3.upload.maximum_size=5310
 
 ##############################################################
@@ -71,19 +102,39 @@ trinket5.name=Adafruit Trinket 16MHz
 trinket5.bootloader.low_fuses=0xF1
 trinket5.bootloader.high_fuses=0xD5
 trinket5.bootloader.extended_fuses=0xFE
-trinket5.bootloader.tool=avrdude
+trinket5.bootloader.tool=arduino:avrdude
 trinket5.build.mcu=attiny85
 trinket5.build.f_cpu=16000000L
 trinket5.build.core=arduino:arduino
 trinket5.build.variant=tiny8
 trinket5.build.board=AVR_TRINKET5
-trinket5.upload.tool=avrdude
+trinket5.upload.tool=arduino:avrdude
 trinket5.upload.maximum_size=5310
+
+##############################################################
+metro.name=Adafruit Metro
+metro.upload.tool=arduino:avrdude
+metro.upload.protocol=arduino
+metro.upload.maximum_size=32256
+metro.upload.maximum_data_size=2048
+metro.upload.speed=115200
+metro.bootloader.tool=arduino:avrdude
+metro.bootloader.low_fuses=0xFF
+metro.bootloader.high_fuses=0xDE
+metro.bootloader.extended_fuses=0x05
+metro.bootloader.unlock_bits=0x3F
+metro.bootloader.lock_bits=0x0F
+metro.bootloader.file=arduino:optiboot/optiboot_atmega328.hex
+metro.build.mcu=atmega328p
+metro.build.f_cpu=16000000L
+metro.build.board=AVR_METRO
+metro.build.core=arduino:arduino
+metro.build.variant=arduino:standard
 
 ##############################################################
 # Pro-Trinket 5V USB Programming Configuration
 protrinket5.name=Pro Trinket 5V/16MHz (USB)
-protrinket5.bootloader.tool=avrdude
+protrinket5.bootloader.tool=arduino:avrdude
 protrinket5.build.mcu=atmega328p
 protrinket5.build.f_cpu=16000000L
 protrinket5.build.core=arduino:arduino
@@ -96,7 +147,7 @@ protrinket5.upload.speed=115200
 ##############################################################
 # Pro-Trinket 3.3V USB Programming Configuration
 protrinket3.name=Pro Trinket 3V/12MHz (USB)
-protrinket3.bootloader.tool=avrdude
+protrinket3.bootloader.tool=arduino:avrdude
 protrinket3.build.mcu=atmega328p
 protrinket3.build.f_cpu=12000000L
 protrinket3.build.core=arduino:arduino
@@ -115,7 +166,7 @@ protrinket5ftdi.bootloader.extended_fuses=0x05
 protrinket5ftdi.bootloader.file=arduino:optiboot/optiboot_atmega328.hex
 protrinket5ftdi.bootloader.unlock_bits=0x3F
 protrinket5ftdi.bootloader.lock_bits=0x0F
-protrinket5ftdi.bootloader.tool=avrdude
+protrinket5ftdi.bootloader.tool=arudino:avrdude
 protrinket5ftdi.build.mcu=atmega328p
 protrinket5ftdi.build.f_cpu=16000000L
 protrinket5ftdi.build.core=arduino:arduino
@@ -129,7 +180,7 @@ protrinket5ftdi.upload.speed=115200
 ##############################################################
 # Pro-Trinket 3.3V Serial/FTDI Programming Configuration
 protrinket3ftdi.name=Pro Trinket 3V/12MHz (FTDI)
-protrinket3ftdi.bootloader.tool=avrdude
+protrinket3ftdi.bootloader.tool=arduino:avrdude
 protrinket3ftdi.bootloader.low_fuses=0xff
 protrinket3ftdi.bootloader.high_fuses=0xde
 protrinket3ftdi.bootloader.extended_fuses=0x05
@@ -145,3 +196,4 @@ protrinket3ftdi.upload.tool=arduino:avrdude
 protrinket3ftdi.upload.protocol=arduino
 protrinket3ftdi.upload.maximum_size=28672
 protrinket3ftdi.upload.speed=115200
+

--- a/hardware/adafruit/avr/platform.txt
+++ b/hardware/adafruit/avr/platform.txt
@@ -5,4 +5,32 @@
 # - https://github.com/arduino/Arduino/wiki/Arduino-Hardware-Cores-migration-guide-from-1.0-to-1.6
 #
 name=Adafruit Boards
-version=1.0.0
+version=1.3.0
+
+# AVR Uploader/Programmers tools
+# ------------------------------
+tools.avrdude.path={runtime.tools.avrdude.path}
+tools.avrdude.cmd.path={path}/bin/avrdude
+tools.avrdude.config.path={runtime.platform.path}/avrdude.conf
+
+tools.avrdude.upload.params.verbose=-v
+tools.avrdude.upload.params.quiet=-q -q
+tools.avrdude.upload.pattern="{cmd.path}" "-C{config.path}" {upload.verbose} -p{build.mcu} -c{upload.protocol} -P{serial.port} -b{upload.speed} -D "-Uflash:w:{build.path}/{build.project_name}.hex:i"
+
+tools.avrdude.program.params.verbose=-v
+tools.avrdude.program.params.quiet=-q -q
+tools.avrdude.program.pattern="{cmd.path}" "-C{config.path}" {program.verbose} -p{build.mcu} -c{protocol} {program.extra_params} "-Uflash:w:{build.path}/{build.project_name}.hex:i"
+
+tools.avrdude.erase.params.verbose=-v
+tools.avrdude.erase.params.quiet=-q -q
+tools.avrdude.erase.pattern="{cmd.path}" "-C{config.path}" {erase.verbose} -p{build.mcu} -c{protocol} {program.extra_params} -e -Ulock:w:{bootloader.unlock_bits}:m -Uefuse:w:{bootloader.extended_fuses}:m -Uhfuse:w:{bootloader.high_fuses}:m -Ulfuse:w:{bootloader.low_fuses}:m
+
+tools.avrdude.bootloader.params.verbose=-v
+tools.avrdude.bootloader.params.quiet=-q -q
+tools.avrdude.bootloader.pattern="{cmd.path}" "-C{config.path}" {bootloader.verbose} -p{build.mcu} -c{protocol} {program.extra_params} "-Uflash:w:{runtime.platform.path}/bootloaders/{bootloader.file}:i" -Ulock:w:{bootloader.lock_bits}:m
+
+# USB Default Flags
+# Default blank usb manufacturer will be filled it at compile time
+# - from numeric vendor ID, set to Unknown otherwise
+build.usb_manufacturer="Unknown"
+build.usb_flags=-DUSB_VID={build.vid} -DUSB_PID={build.pid} '-DUSB_MANUFACTURER={build.usb_manufacturer}' '-DUSB_PRODUCT={build.usb_product}'

--- a/hardware/adafruit/avr/variants/bluefruitmicro/pins_arduino.h
+++ b/hardware/adafruit/avr/variants/bluefruitmicro/pins_arduino.h
@@ -1,0 +1,257 @@
+/*
+  pins_arduino.h - Pin definition functions for Arduino
+  Part of Arduino - http://www.arduino.cc/
+
+  Copyright (c) 2007 David A. Mellis
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General
+  Public License along with this library; if not, write to the
+  Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+  Boston, MA  02111-1307  USA
+
+  $Id: wiring.h 249 2007-02-03 16:52:51Z mellis $
+*/
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <avr/pgmspace.h>
+
+
+#define TXLED0			0
+#define TXLED1			0
+#define RXLED0			0
+#define RXLED1			0
+#define TX_RX_LED_INIT	0
+
+static const uint8_t SDA = 2;
+static const uint8_t SCL = 3;
+
+// Map SPI port to 'new' pins D14..D17
+static const uint8_t SS   = 17;
+static const uint8_t MOSI = 16;
+static const uint8_t MISO = 14;
+static const uint8_t SCK  = 15;
+
+// Mapping of analog pins as digital I/O
+// A6-A11 share with digital pins
+static const uint8_t A0 = 18;
+static const uint8_t A1 = 19;
+static const uint8_t A2 = 20;
+static const uint8_t A3 = 21;
+static const uint8_t A4 = 22;
+static const uint8_t A5 = 23;
+static const uint8_t A6 = 24;	// D4
+static const uint8_t A7 = 25;	// D6
+static const uint8_t A8 = 26;	// D8
+static const uint8_t A9 = 27;	// D9
+static const uint8_t A10 = 28;	// D10
+static const uint8_t A11 = 29;	// D12
+
+#define digitalPinToPCICR(p)    ((((p) >= 8 && (p) <= 11) || ((p) >= 14 && (p) <= 17) || ((p) >= A8 && (p) <= A10)) ? (&PCICR) : ((uint8_t *)0))
+#define digitalPinToPCICRbit(p) 0
+#define digitalPinToPCMSK(p)    ((((p) >= 8 && (p) <= 11) || ((p) >= 14 && (p) <= 17) || ((p) >= A8 && (p) <= A10)) ? (&PCMSK0) : ((uint8_t *)0))
+#define digitalPinToPCMSKbit(p) ( ((p) >= 8 && (p) <= 11) ? (p) - 4 : ((p) == 14 ? 3 : ((p) == 15 ? 1 : ((p) == 16 ? 2 : ((p) == 17 ? 0 : (p - A8 + 4))))))
+
+//	__AVR_ATmega32U4__ has an unusual mapping of pins to channels
+extern const uint8_t PROGMEM analog_pin_to_channel_PGM[];
+#define analogPinToChannel(P)  ( pgm_read_byte( analog_pin_to_channel_PGM + (P) ) )
+
+#ifdef ARDUINO_MAIN
+
+// On the Arduino board, digital pins are also used
+// for the analog output (software PWM).  Analog input
+// pins are a separate set.
+
+// ATMEL ATMEGA32U4 / ARDUINO LEONARDO / Flora
+//
+// D0				PD2					RXD1/INT2
+// D1				PD3					TXD1/INT3
+// D2				PD1		SDA			SDA/INT1
+// D3#				PD0		PWM8/SCL	OC0B/SCL/INT0
+// D4		A6		PD4					ADC8
+// D5#				PC6		???			OC3A/#OC4A
+// D6#		A7		PD7		FastPWM		#OC4D/ADC10
+// D7				PE6					INT6/AIN0
+//
+// D8		A8		PB4					ADC11/PCINT4
+// D9#		A9		PB5		PWM16		OC1A/#OC4B/ADC12/PCINT5
+// D10#		A10		PB6		PWM16		OC1B/0c4B/ADC13/PCINT6
+// D11#				PB7		PWM8/16		0C0A/OC1C/#RTS/PCINT7
+// D12		A11		PD6					T1/#OC4D/ADC9
+// D13#				PC7		PWM10		CLK0/OC4A
+//
+// A0		D18		PF7					ADC7
+// A1		D19		PF6					ADC6
+// A2		D20 	PF5					ADC5
+// A3		D21 	PF4					ADC4
+// A4		D22		PF1					ADC1
+// A5		D23 	PF0					ADC0
+//
+// New pins D14..D17 to map SPI port to digital pins
+//
+// MISO		D14		PB3					MISO,PCINT3
+// SCK		D15		PB1					SCK,PCINT1
+// MOSI		D16		PB2					MOSI,PCINT2
+// SS		D17		PB0					RXLED,SS/PCINT0
+//
+// TXLED			PD5
+// RXLED		    PB0
+// HWB				PE2					HWB
+
+// these arrays map port names (e.g. port B) to the
+// appropriate addresses for various functions (e.g. reading
+// and writing)
+const uint16_t PROGMEM port_to_mode_PGM[] = {
+	NOT_A_PORT,
+	NOT_A_PORT,
+	(uint16_t) &DDRB,
+	(uint16_t) &DDRC,
+	(uint16_t) &DDRD,
+	(uint16_t) &DDRE,
+	(uint16_t) &DDRF,
+};
+
+const uint16_t PROGMEM port_to_output_PGM[] = {
+	NOT_A_PORT,
+	NOT_A_PORT,
+	(uint16_t) &PORTB,
+	(uint16_t) &PORTC,
+	(uint16_t) &PORTD,
+	(uint16_t) &PORTE,
+	(uint16_t) &PORTF,
+};
+
+const uint16_t PROGMEM port_to_input_PGM[] = {
+	NOT_A_PORT,
+	NOT_A_PORT,
+	(uint16_t) &PINB,
+	(uint16_t) &PINC,
+	(uint16_t) &PIND,
+	(uint16_t) &PINE,
+	(uint16_t) &PINF,
+};
+
+const uint8_t PROGMEM digital_pin_to_port_PGM[30] = {
+	PD, // D0 - PD2
+	PD,	// D1 - PD3
+	PD, // D2 - PD1
+	PD,	// D3 - PD0
+	PD,	// D4 - PD4
+	PC, // D5 - PC6
+	PD, // D6 - PD7
+	PE, // D7 - PE6
+
+	PB, // D8 - PB4
+	PB,	// D9 - PB5
+	PB, // D10 - PB6
+	PB,	// D11 - PB7
+	PD, // D12 - PD6
+	PC, // D13 - PC7
+
+	PB,	// D14 - MISO - PB3
+	PB,	// D15 - SCK - PB1
+	PB,	// D16 - MOSI - PB2
+	PB,	// D17 - SS - PB0
+
+	PF,	// D18 - A0 - PF7
+	PF, // D19 - A1 - PF6
+	PF, // D20 - A2 - PF5
+	PF, // D21 - A3 - PF4
+	PF, // D22 - A4 - PF1
+	PF, // D23 - A5 - PF0
+
+	PD, // D24 / D4 - A6 - PD4
+	PD, // D25 / D6 - A7 - PD7
+	PB, // D26 / D8 - A8 - PB4
+	PB, // D27 / D9 - A9 - PB5
+	PB, // D28 / D10 - A10 - PB6
+	PD, // D29 / D12 - A11 - PD6
+};
+
+const uint8_t PROGMEM digital_pin_to_bit_mask_PGM[30] = {
+	_BV(2), // D0 - PD2
+	_BV(3),	// D1 - PD3
+	_BV(1), // D2 - PD1
+	_BV(0),	// D3 - PD0
+	_BV(4),	// D4 - PD4
+	_BV(6), // D5 - PC6
+	_BV(7), // D6 - PD7
+	_BV(6), // D7 - PE6
+
+	_BV(4), // D8 - PB4
+	_BV(5),	// D9 - PB5
+	_BV(6), // D10 - PB6
+	_BV(7),	// D11 - PB7
+	_BV(6), // D12 - PD6
+	_BV(7), // D13 - PC7
+
+	_BV(3),	// D14 - MISO - PB3
+	_BV(1),	// D15 - SCK - PB1
+	_BV(2),	// D16 - MOSI - PB2
+	_BV(0),	// D17 - SS - PB0
+
+	_BV(7),	// D18 - A0 - PF7
+	_BV(6), // D19 - A1 - PF6
+	_BV(5), // D20 - A2 - PF5
+	_BV(4), // D21 - A3 - PF4
+	_BV(1), // D22 - A4 - PF1
+	_BV(0), // D23 - A5 - PF0
+
+	_BV(4), // D24 / D4 - A6 - PD4
+	_BV(7), // D25 / D6 - A7 - PD7
+	_BV(4), // D26 / D8 - A8 - PB4
+	_BV(5), // D27 / D9 - A9 - PB5
+	_BV(6), // D28 / D10 - A10 - PB6
+	_BV(6), // D29 / D12 - A11 - PD6
+};
+
+const uint8_t PROGMEM digital_pin_to_timer_PGM[16] = {
+	NOT_ON_TIMER,
+	NOT_ON_TIMER,
+	NOT_ON_TIMER,
+	TIMER0B,		/* 3 */
+	NOT_ON_TIMER,
+	TIMER3A,		/* 5 */
+	TIMER4D,		/* 6 */
+	NOT_ON_TIMER,
+
+	NOT_ON_TIMER,
+	TIMER1A,		/* 9 */
+	TIMER1B,		/* 10 */
+	TIMER0A,		/* 11 */
+
+	NOT_ON_TIMER,
+	TIMER4A,		/* 13 */
+
+	NOT_ON_TIMER,
+	NOT_ON_TIMER,
+};
+
+const uint8_t PROGMEM analog_pin_to_channel_PGM[12] = {
+	7,	// A0				PF7					ADC7
+	6,	// A1				PF6					ADC6
+	5,	// A2				PF5					ADC5
+	4,	// A3				PF4					ADC4
+	1,	// A4				PF1					ADC1
+	0,	// A5				PF0					ADC0
+	8,	// A6		D4		PD4					ADC8
+	10,	// A7		D6		PD7					ADC10
+	11,	// A8		D8		PB4					ADC11
+	12,	// A9		D9		PB5					ADC12
+	13,	// A10		D10		PB6					ADC13
+	9	// A11		D12		PD6					ADC9
+};
+
+#endif /* ARDUINO_MAIN */
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Changes
- Adds Bluefruit Micro to `boards.txt`
- Adds `bluefruitmicro` variant
- Adds `build_package.sh` bash script to package the core for the Adafruit package index
## Running a Package Build

Run the `build_package.sh` script and enter a new version:

```
$ ./build_package.sh 
VERSION [1.3.0]: 1.3.0
```

The resulting archive will then be available in the `build/` folder along with the JSON needed to add to the package index file in the [adafruit/arduino-board-index](https://github.com/adafruit/arduino-board-index) repo:

```
├── build
│   ├── adafruit-1.3.0.tar.bz2
│   └── package.json
```
